### PR TITLE
Sort grammar rewrite and bugfix with multiple fields

### DIFF
--- a/src/test/java/com/teragrep/pth_03/SortSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/SortSyntaxTests.java
@@ -1,0 +1,199 @@
+/*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.pth_03;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.w3c.dom.NodeList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SortSyntaxTests {
+
+    @ParameterizedTest(name = "{index} command=''{0}''")
+    @ValueSource(strings = {
+            "sort",
+            "sortdesc",
+            "sortlimitbyint",
+            "sortminusplus",
+            "sortmodes"
+    })
+    public void sortSyntaxParseTest(String arg) {
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+        ParserSyntaxTestingUtility parserSyntaxTestingUtility
+                = new ParserSyntaxTestingUtility(fileName, false);
+        Assertions.assertDoesNotThrow(() -> parserSyntaxTestingUtility.syntaxParseTest(arg));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sort",
+    })
+    void sortWithThreeFieldsTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+        String sortPath = "/root/transformStatement/sortTransformation";
+        String byClausePath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/sortFieldType";
+
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+        NodeList byClauseNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, byClausePath, true));
+
+        // Check that the correct amount is found
+        assertEquals(1,sortNode.getLength());
+        assertEquals(3,byClauseNode.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortdesc",
+    })
+    void sortDescTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+        String descPath = "/root/transformStatement/sortTransformation/t_sort_dParameter";
+        String byClausePath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/sortFieldType";
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+        NodeList descNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, descPath, false));
+        NodeList byClauseNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, byClausePath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1,sortNode.getLength());
+        assertEquals(2,descNode.getLength());
+        assertEquals(2,byClauseNode.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortlimitbyint",
+    })
+    void sortLimitByIntTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+        String limitIntPath = "/root/transformStatement/sortTransformation/t_sort_integerType";
+        String byClausePath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/sortFieldType";
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+        NodeList limitIntNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, limitIntPath, false));
+        NodeList byClauseNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, byClausePath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1,sortNode.getLength());
+        assertEquals(1,limitIntNode.getLength());
+        assertEquals(1,byClauseNode.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortminusplus",
+    })
+    void sortMinusPlusTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+        String plusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sortPlusOption";
+        String minusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sortMinusOption";
+        String byClausePath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/sortFieldType";
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+        NodeList plusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, plusPath, false));
+        NodeList minusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, minusPath, false));
+        NodeList byClauseNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, byClausePath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1, sortNode.getLength());
+        assertEquals(1, minusNode.getLength());
+        assertEquals(1, plusNode.getLength());
+        assertEquals(2, byClauseNode.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortmodes",
+    })
+    void sortModes(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+        String autoPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodAuto/fieldType";
+        String strPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodStr/fieldType";
+        String numPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodNum/fieldType";
+        String ipPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodIp/fieldType";
+        String limitPath = "/root/transformStatement/sortTransformation/t_sort_limitParameter/integerType";
+
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+        NodeList autoNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, autoPath, false));
+        NodeList strNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, strPath, false));
+        NodeList numNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numPath, false));
+        NodeList ipNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, ipPath, false));
+        NodeList limitNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, limitPath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1,sortNode.getLength());
+        assertEquals(1,autoNode.getLength());
+        assertEquals(1,strNode.getLength());
+        assertEquals(1,numNode.getLength());
+        assertEquals(1,ipNode.getLength());
+        assertEquals(1,limitNode.getLength());
+    }
+}

--- a/src/test/java/com/teragrep/pth_03/tests/SortSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/SortSyntaxTests.java
@@ -44,8 +44,10 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.pth_03;
+package com.teragrep.pth_03.tests;
 
+import com.teragrep.pth_03.ParserStructureTestingUtility;
+import com.teragrep.pth_03.ParserSyntaxTestingUtility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -167,7 +169,7 @@ public class SortSyntaxTests {
     @ValueSource(strings = {
             "sortmodes",
     })
-    void sortModes(String arg) {
+    void sortModesTest(String arg) {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
 
@@ -195,5 +197,102 @@ public class SortSyntaxTests {
         assertEquals(1,numNode.getLength());
         assertEquals(1,ipNode.getLength());
         assertEquals(1,limitNode.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortmodesminus",
+    })
+    void sortModesMinusTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+
+        String autoPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodAuto/fieldType";
+        String strPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodStr/fieldType";
+        String numPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodNum/fieldType";
+        String ipPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodIp/fieldType";
+
+        String autoMinusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodAuto/t_sortMinusOption";
+        String strMinusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodStr/t_sortMinusOption";
+        String numMinusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodNum/t_sortMinusOption";
+        String ipMinusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodIp/t_sortMinusOption";
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+
+        NodeList autoNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, autoPath, false));
+        NodeList strNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, strPath, false));
+        NodeList numNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numPath, false));
+        NodeList ipNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, ipPath, false));
+
+        NodeList autoMinusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, autoMinusPath, false));
+        NodeList strMinusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, strMinusPath, false));
+        NodeList numMinusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numMinusPath, false));
+        NodeList ipMinusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, ipMinusPath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1,sortNode.getLength());
+
+        assertEquals(1,autoNode.getLength());
+        assertEquals(1,strNode.getLength());
+        assertEquals(1,numNode.getLength());
+        assertEquals(1,ipNode.getLength());
+
+        assertEquals(1,autoMinusNode.getLength());
+        assertEquals(1,strMinusNode.getLength());
+        assertEquals(1,numMinusNode.getLength());
+        assertEquals(1,ipMinusNode.getLength());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "sortmodesplus",
+    })
+    void sortModesPlusTest(String arg) {
+        ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        String fileName = "src/test/resources/antlr4/commands/sort/" + arg + ".txt";
+
+        // Specify parse tree paths for each parameter
+        String sortPath = "/root/transformStatement/sortTransformation";
+
+        String autoPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodAuto/fieldType";
+        String strPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodStr/fieldType";
+        String numPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodNum/fieldType";
+        String ipPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodIp/fieldType";
+
+        String autoPlusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodAuto/t_sortPlusOption";
+        String strPlusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodStr/t_sortPlusOption";
+        String numPlusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodNum/t_sortPlusOption";
+        String ipPlusPath = "/root/transformStatement/sortTransformation/t_sort_sortByClauseInstruction/t_sort_byMethodIp/t_sortPlusOption";
+
+        // Get the list of nodes in a specific parse tree path
+        NodeList sortNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, sortPath, false));
+
+        NodeList autoNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, autoPath, false));
+        NodeList strNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, strPath, false));
+        NodeList numNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numPath, false));
+        NodeList ipNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, ipPath, false));
+
+        NodeList autoPlusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, autoPlusPath, false));
+        NodeList strPlusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, strPlusPath, false));
+        NodeList numPlusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numPlusPath, false));
+        NodeList ipPlusNode = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, ipPlusPath, false));
+
+        // Check that the correct amount of nodes is found
+        assertEquals(1,sortNode.getLength());
+
+        assertEquals(1,autoNode.getLength());
+        assertEquals(1,strNode.getLength());
+        assertEquals(1,numNode.getLength());
+        assertEquals(1,ipNode.getLength());
+
+        assertEquals(1,autoPlusNode.getLength());
+        assertEquals(1,strPlusNode.getLength());
+        assertEquals(1,numPlusNode.getLength());
+        assertEquals(1,ipPlusNode.getLength());
     }
 }

--- a/src/test/resources/antlr4/commands/sort/sort.txt
+++ b/src/test/resources/antlr4/commands/sort/sort.txt
@@ -1,4 +1,4 @@
-/*
+<!-- /*
  * Teragrep Data Processing Language Parser Library PTH-03
  * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
  *
@@ -42,53 +42,5 @@
  * To the extent this program is licensed as part of the Commercial versions of
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
- */
-parser grammar DPLParserTransform_sort;
-
-sortTransformation
-        : COMMAND_MODE_SORT (t_sort_integerType | t_sort_limitParameter | t_sort_dParameter | COMMA? t_sort_sortByClauseInstruction)*
-        ;
-
-t_sort_sortByClauseInstruction
-        : (t_sort_byMethodAuto|t_sort_byMethodStr|t_sort_byMethodIp|t_sort_byMethodNum)
-        | ((t_sortMinusOption | t_sortPlusOption)? sortFieldType)
-        ;
-
-t_sort_dParameter
-        : COMMAND_SORT_MODE_D
-        | COMMAND_SORT_MODE_DESC
-        ;
-
-t_sort_limitParameter
-        : COMMAND_SORT_MODE_LIMIT integerType
-        ;
-
-t_sort_byMethodAuto
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_AUTO ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodStr
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_STR ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodIp
-        :  (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_IP COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodNum
-        : (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_NUM  COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sortMinusOption
-        : COMMAND_SORT_MODE_MINUS
-        ;
-
-t_sortPlusOption
-        : COMMAND_SORT_MODE_PLUS
-        ;
-
-t_sort_integerType
-        : COMMAND_SORT_MODE_INTEGER
-        ;
-
-
+ */ -->
+| sort foo, bar, foobar

--- a/src/test/resources/antlr4/commands/sort/sortdesc.txt
+++ b/src/test/resources/antlr4/commands/sort/sortdesc.txt
@@ -1,4 +1,4 @@
-/*
+<!-- /*
  * Teragrep Data Processing Language Parser Library PTH-03
  * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
  *
@@ -42,53 +42,5 @@
  * To the extent this program is licensed as part of the Commercial versions of
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
- */
-parser grammar DPLParserTransform_sort;
-
-sortTransformation
-        : COMMAND_MODE_SORT (t_sort_integerType | t_sort_limitParameter | t_sort_dParameter | COMMA? t_sort_sortByClauseInstruction)*
-        ;
-
-t_sort_sortByClauseInstruction
-        : (t_sort_byMethodAuto|t_sort_byMethodStr|t_sort_byMethodIp|t_sort_byMethodNum)
-        | ((t_sortMinusOption | t_sortPlusOption)? sortFieldType)
-        ;
-
-t_sort_dParameter
-        : COMMAND_SORT_MODE_D
-        | COMMAND_SORT_MODE_DESC
-        ;
-
-t_sort_limitParameter
-        : COMMAND_SORT_MODE_LIMIT integerType
-        ;
-
-t_sort_byMethodAuto
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_AUTO ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodStr
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_STR ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodIp
-        :  (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_IP COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodNum
-        : (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_NUM  COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sortMinusOption
-        : COMMAND_SORT_MODE_MINUS
-        ;
-
-t_sortPlusOption
-        : COMMAND_SORT_MODE_PLUS
-        ;
-
-t_sort_integerType
-        : COMMAND_SORT_MODE_INTEGER
-        ;
-
-
+ */ -->
+ | sort field1 desc, field2 d

--- a/src/test/resources/antlr4/commands/sort/sortlimitbyint.txt
+++ b/src/test/resources/antlr4/commands/sort/sortlimitbyint.txt
@@ -1,4 +1,4 @@
-/*
+<!-- /*
  * Teragrep Data Processing Language Parser Library PTH-03
  * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
  *
@@ -42,53 +42,5 @@
  * To the extent this program is licensed as part of the Commercial versions of
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
- */
-parser grammar DPLParserTransform_sort;
-
-sortTransformation
-        : COMMAND_MODE_SORT (t_sort_integerType | t_sort_limitParameter | t_sort_dParameter | COMMA? t_sort_sortByClauseInstruction)*
-        ;
-
-t_sort_sortByClauseInstruction
-        : (t_sort_byMethodAuto|t_sort_byMethodStr|t_sort_byMethodIp|t_sort_byMethodNum)
-        | ((t_sortMinusOption | t_sortPlusOption)? sortFieldType)
-        ;
-
-t_sort_dParameter
-        : COMMAND_SORT_MODE_D
-        | COMMAND_SORT_MODE_DESC
-        ;
-
-t_sort_limitParameter
-        : COMMAND_SORT_MODE_LIMIT integerType
-        ;
-
-t_sort_byMethodAuto
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_AUTO ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodStr
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_STR ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodIp
-        :  (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_IP COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodNum
-        : (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_NUM  COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sortMinusOption
-        : COMMAND_SORT_MODE_MINUS
-        ;
-
-t_sortPlusOption
-        : COMMAND_SORT_MODE_PLUS
-        ;
-
-t_sort_integerType
-        : COMMAND_SORT_MODE_INTEGER
-        ;
-
-
+ */ -->
+ | sort 5 field

--- a/src/test/resources/antlr4/commands/sort/sortminusplus.txt
+++ b/src/test/resources/antlr4/commands/sort/sortminusplus.txt
@@ -1,4 +1,4 @@
-/*
+<!-- /*
  * Teragrep Data Processing Language Parser Library PTH-03
  * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
  *
@@ -42,53 +42,5 @@
  * To the extent this program is licensed as part of the Commercial versions of
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
- */
-parser grammar DPLParserTransform_sort;
-
-sortTransformation
-        : COMMAND_MODE_SORT (t_sort_integerType | t_sort_limitParameter | t_sort_dParameter | COMMA? t_sort_sortByClauseInstruction)*
-        ;
-
-t_sort_sortByClauseInstruction
-        : (t_sort_byMethodAuto|t_sort_byMethodStr|t_sort_byMethodIp|t_sort_byMethodNum)
-        | ((t_sortMinusOption | t_sortPlusOption)? sortFieldType)
-        ;
-
-t_sort_dParameter
-        : COMMAND_SORT_MODE_D
-        | COMMAND_SORT_MODE_DESC
-        ;
-
-t_sort_limitParameter
-        : COMMAND_SORT_MODE_LIMIT integerType
-        ;
-
-t_sort_byMethodAuto
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_AUTO ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodStr
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_STR ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodIp
-        :  (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_IP COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodNum
-        : (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_NUM  COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sortMinusOption
-        : COMMAND_SORT_MODE_MINUS
-        ;
-
-t_sortPlusOption
-        : COMMAND_SORT_MODE_PLUS
-        ;
-
-t_sort_integerType
-        : COMMAND_SORT_MODE_INTEGER
-        ;
-
-
+ */ -->
+ | sort -field1 +field2

--- a/src/test/resources/antlr4/commands/sort/sortmodes.txt
+++ b/src/test/resources/antlr4/commands/sort/sortmodes.txt
@@ -1,4 +1,4 @@
-/*
+<!-- /*
  * Teragrep Data Processing Language Parser Library PTH-03
  * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
  *
@@ -42,53 +42,6 @@
  * To the extent this program is licensed as part of the Commercial versions of
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
- */
-parser grammar DPLParserTransform_sort;
+ */ -->
 
-sortTransformation
-        : COMMAND_MODE_SORT (t_sort_integerType | t_sort_limitParameter | t_sort_dParameter | COMMA? t_sort_sortByClauseInstruction)*
-        ;
-
-t_sort_sortByClauseInstruction
-        : (t_sort_byMethodAuto|t_sort_byMethodStr|t_sort_byMethodIp|t_sort_byMethodNum)
-        | ((t_sortMinusOption | t_sortPlusOption)? sortFieldType)
-        ;
-
-t_sort_dParameter
-        : COMMAND_SORT_MODE_D
-        | COMMAND_SORT_MODE_DESC
-        ;
-
-t_sort_limitParameter
-        : COMMAND_SORT_MODE_LIMIT integerType
-        ;
-
-t_sort_byMethodAuto
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_AUTO ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodStr
-        : ( (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_STR ) COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodIp
-        :  (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_IP COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sort_byMethodNum
-        : (t_sortMinusOption | t_sortPlusOption)? COMMAND_SORT_MODE_NUM  COMMAND_SORT_MODE_PARENTHESIS_L fieldType COMMAND_SORT_MODE_PARENTHESIS_R
-        ;
-
-t_sortMinusOption
-        : COMMAND_SORT_MODE_MINUS
-        ;
-
-t_sortPlusOption
-        : COMMAND_SORT_MODE_PLUS
-        ;
-
-t_sort_integerType
-        : COMMAND_SORT_MODE_INTEGER
-        ;
-
-
+ | sort auto(field), num(field2), str(field3), ip(field4) limit=5

--- a/src/test/resources/antlr4/commands/sort/sortmodesminus.txt
+++ b/src/test/resources/antlr4/commands/sort/sortmodesminus.txt
@@ -1,0 +1,47 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+
+ | sort -auto(field), -num(field2), -str(field3), -ip(field4)

--- a/src/test/resources/antlr4/commands/sort/sortmodesplus.txt
+++ b/src/test/resources/antlr4/commands/sort/sortmodesplus.txt
@@ -1,0 +1,47 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+
+ | sort +auto(field), +num(field2), +str(field3), +ip(field4)


### PR DESCRIPTION
Fixes #49 and #64 .

Rewrote sort command's grammar to allow multiple fields with a comma delimiter.
Grammar was refactored because it didn't support having the optional parameters anywhere in the query. So, the main change is the main grammar rule in sort which now allows having the parameters in any order and as many times as wanted. Now it is more or less left for PTH-10 to check that the parameters are given just once etc.

Added a new grammar rule for the plus sign: differentiated it from the minus for easier visiting in PTH-10.

Wrote unit tests for sort command, there weren't any before.