### PR TITLE
Moved SyntaxErrorTests from pth-10

### DIFF
--- a/src/test/java/com/teragrep/pth_03/tests/EvalSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/EvalSyntaxTests.java
@@ -55,6 +55,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.w3c.dom.NodeList;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class EvalSyntaxTests {
     @ParameterizedTest(name = "{index} command=''{0}''")
     @ValueSource(strings = {
@@ -493,5 +495,17 @@ public class EvalSyntaxTests {
 
         NodeList numberNode2 = Assertions.assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, numberParam2, false));
         assertEquals(1, numberNode2.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "missingParameterInIf"
+    })
+    void missingParameterInIfTest(String arg) {
+        String fileName = "src/test/resources/antlr4/commands/eval/" + arg + ".txt";
+        ParserSyntaxTestingUtility pstu = new ParserSyntaxTestingUtility(fileName,false);
+
+        // Invalid syntax should throw an exception.
+        Assertions.assertThrows(InvocationTargetException.class, () -> pstu.syntaxParseTest(arg));
     }
 }

--- a/src/test/java/com/teragrep/pth_03/tests/LogicalOperationSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/LogicalOperationSyntaxTests.java
@@ -1,0 +1,109 @@
+/*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth_03.tests;
+
+import com.teragrep.pth_03.ParserSyntaxTestingUtility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.lang.reflect.InvocationTargetException;
+
+public class LogicalOperationSyntaxTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "missingBracket",
+    })
+    void missingBracketTest(String arg) {
+        String fileName = "src/test/resources/antlr4/logicalOperations/" + arg + ".txt";
+        ParserSyntaxTestingUtility parserSyntaxTestingUtility
+                = new ParserSyntaxTestingUtility(fileName, false);
+
+        // Invalid syntax should throw an exception.
+        Assertions.assertThrows(InvocationTargetException.class, () -> parserSyntaxTestingUtility.syntaxParseTest(arg));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "missingClosingBracket",
+    })
+    void missingClosingBracketTest(String arg) {
+        String fileName = "src/test/resources/antlr4/logicalOperations/" + arg + ".txt";
+        ParserSyntaxTestingUtility parserSyntaxTestingUtility
+                = new ParserSyntaxTestingUtility(fileName, false);
+
+        // Invalid syntax should throw an exception.
+        Assertions.assertThrows(InvocationTargetException.class, () -> parserSyntaxTestingUtility.syntaxParseTest(arg));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "invalidCharacters",
+    })
+    void invalidCharactersTest(String arg) {
+        String fileName = "src/test/resources/antlr4/logicalOperations/" + arg + ".txt";
+        ParserSyntaxTestingUtility parserSyntaxTestingUtility
+                = new ParserSyntaxTestingUtility(fileName, false);
+
+        // Invalid syntax should throw an exception.
+        Assertions.assertThrows(InvocationTargetException.class, () -> parserSyntaxTestingUtility.syntaxParseTest(arg));
+    }
+
+    @Disabled(value="pth-03 issue #76")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "unbalancedQuotes",
+    })
+    void unbalancedQuotesTest(String arg) {
+        String fileName = "src/test/resources/antlr4/logicalOperations/" + arg + ".txt";
+        ParserSyntaxTestingUtility parserSyntaxTestingUtility
+                = new ParserSyntaxTestingUtility(fileName, false);
+
+        // Invalid syntax should throw an exception.
+        Assertions.assertThrows(InvocationTargetException.class, () -> parserSyntaxTestingUtility.syntaxParseTest(arg));
+    }
+}

--- a/src/test/resources/antlr4/commands/eval/missingParameterInIf.txt
+++ b/src/test/resources/antlr4/commands/eval/missingParameterInIf.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+index = example | eval field1 = if(_raw=49,"true")

--- a/src/test/resources/antlr4/logicalOperations/invalidCharacters.txt
+++ b/src/test/resources/antlr4/logicalOperations/invalidCharacters.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+index = archive_memory ( host = \"localhost\" OR host = \"test\" @))) < AND sourcetype = \"memory\" Deny

--- a/src/test/resources/antlr4/logicalOperations/missingBracket.txt
+++ b/src/test/resources/antlr4/logicalOperations/missingBracket.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+index = archive_memory ( host = "localhost"  Deny

--- a/src/test/resources/antlr4/logicalOperations/missingClosingBracket.txt
+++ b/src/test/resources/antlr4/logicalOperations/missingClosingBracket.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+index = archive_memory host = "localhost" )  Deny

--- a/src/test/resources/antlr4/logicalOperations/unbalancedQuotes.txt
+++ b/src/test/resources/antlr4/logicalOperations/unbalancedQuotes.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+index = archive_memory host = \"testlocalhost


### PR DESCRIPTION
Added LogicalOperationSyntaxTests  and a disabled syntax test for missing quotes in a field because it did not throw an exception while it should, issue: #76 

Also added a test case for if statement 

Related PR from pth-10: https://github.com/teragrep/pth_10/pull/346


Related issue from pth-10: https://github.com/teragrep/pth_10/issues/322
