### PR TITLE
Rework renaming columns in | timechart

### DIFF
--- a/src/main/antlr4/imports/DPLParserTransform_timechart.g4
+++ b/src/main/antlr4/imports/DPLParserTransform_timechart.g4
@@ -46,11 +46,15 @@
 parser grammar DPLParserTransform_timechart;
 
 timechartTransformation
-        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter t_timechart_fieldRenameInstruction?)*? (t_timechart_binOptParameter)*? ((aggregateFunction t_timechart_fieldRenameInstruction? | t_timechart_evaledField t_timechart_fieldRenameInstruction?) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
+        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter)*? (t_timechart_binOptParameter)*? ((t_timechart_aggregation | t_timechart_evaledField) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
         ;
 
 t_timechart_aggParameter
-        : COMMAND_TIMECHART_MODE_AGG(((aggregateFunction | t_timechart_evaledField | fieldType)))
+        : COMMAND_TIMECHART_MODE_AGG(((aggregateFunction | t_timechart_evaledField | fieldType))) t_timechart_fieldRenameInstruction?
+        ;
+
+t_timechart_aggregation
+        : aggregateFunction t_timechart_fieldRenameInstruction?
         ;
 
 t_timechart_binOptParameter
@@ -150,7 +154,7 @@ t_timechart_useotherParameter
 
 
 t_timechart_evaledField
-        : COMMAND_TIMECHART_MODE_EVAL_PARENTHESIS_L evalStatement EVAL_LANGUAGE_MODE_PARENTHESIS_R
+        : COMMAND_TIMECHART_MODE_EVAL_PARENTHESIS_L evalStatement EVAL_LANGUAGE_MODE_PARENTHESIS_R t_timechart_fieldRenameInstruction?
         ;
 
 t_timechart_fieldRenameInstruction

--- a/src/main/antlr4/imports/DPLParserTransform_timechart.g4
+++ b/src/main/antlr4/imports/DPLParserTransform_timechart.g4
@@ -46,7 +46,7 @@
 parser grammar DPLParserTransform_timechart;
 
 timechartTransformation
-        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter)*? (t_timechart_binOptParameter)*? ((t_timechart_aggregation | t_timechart_evaledField) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
+        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter)*? (t_timechart_binOptParameter)*? ((t_timechart_aggregation | t_timechart_renamedEvaledField) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
         ;
 
 t_timechart_aggParameter
@@ -154,7 +154,11 @@ t_timechart_useotherParameter
 
 
 t_timechart_evaledField
-        : COMMAND_TIMECHART_MODE_EVAL_PARENTHESIS_L evalStatement EVAL_LANGUAGE_MODE_PARENTHESIS_R t_timechart_fieldRenameInstruction?
+        : COMMAND_TIMECHART_MODE_EVAL_PARENTHESIS_L evalStatement EVAL_LANGUAGE_MODE_PARENTHESIS_R
+        ;
+
+t_timechart_renamedEvaledField
+        : t_timechart_evaledField t_timechart_fieldRenameInstruction?
         ;
 
 t_timechart_fieldRenameInstruction

--- a/src/main/antlr4/imports/DPLParserTransform_timechart.g4
+++ b/src/main/antlr4/imports/DPLParserTransform_timechart.g4
@@ -46,7 +46,7 @@
 parser grammar DPLParserTransform_timechart;
 
 timechartTransformation
-        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter)*? (t_timechart_binOptParameter)*? ((t_timechart_aggregation | t_timechart_renamedEvaledField) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
+        : COMMAND_MODE_TIMECHART (t_timechart_sepParameter | t_timechart_formatParameter | t_timechart_partialParameter | t_timechart_fixedrangeParameter | t_timechart_contParameter | t_timechart_limitParameter)*? (t_timechart_aggParameter)*? (t_timechart_binOptParameter)*? ((t_timechart_aggregation | t_timechart_renameableEvaledField) t_timechart_divideByInstruction?)+ t_timechart_dedupSplitParameter?
         ;
 
 t_timechart_aggParameter
@@ -157,7 +157,7 @@ t_timechart_evaledField
         : COMMAND_TIMECHART_MODE_EVAL_PARENTHESIS_L evalStatement EVAL_LANGUAGE_MODE_PARENTHESIS_R
         ;
 
-t_timechart_renamedEvaledField
+t_timechart_renameableEvaledField
         : t_timechart_evaledField t_timechart_fieldRenameInstruction?
         ;
 

--- a/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
@@ -483,8 +483,8 @@ public class TimechartSyntaxTests {
         final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
 
-        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_renamedEvaledField/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
-        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_renamedEvaledField/t_timechart_fieldRenameInstruction/fieldType/value";
+        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_renameableEvaledField/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
+        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_renameableEvaledField/t_timechart_fieldRenameInstruction/fieldType/value";
 
         final NodeList evalNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, evalPath, false));
         final NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));

--- a/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
@@ -48,6 +48,7 @@ package com.teragrep.pth_03.tests;
 import com.teragrep.pth_03.ParserStructureTestingUtility;
 import com.teragrep.pth_03.ParserSyntaxTestingUtility;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,6 +68,7 @@ public class TimechartSyntaxTests {
             "timechart9",
             "timechart10",
             "timechart11",
+            "timechartEvaledField"
     })
     public void timechartSyntaxParseTest(String arg) throws Exception {
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
@@ -148,7 +150,7 @@ public class TimechartSyntaxTests {
     void xpathTest6(String arg) throws Exception {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
-        String xpathExp = "/root/transformStatement/timechartTransformation/aggregateFunction/aggregateMethodCount/value[1]";
+        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodCount/value[1]";
 
         NodeList nodesA = (NodeList) pstu.xpathQueryFile(fileName, xpathExp, false);
         // Check that 1 found
@@ -187,7 +189,7 @@ public class TimechartSyntaxTests {
     void xpathTest9(String arg) throws Exception {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
-        String xpathExp = "/root/transformStatement/timechartTransformation/aggregateFunction/aggregateMethodCount/value";
+        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodCount/value";
 
         NodeList nodesA = (NodeList) pstu.xpathQueryFile(fileName, xpathExp, false);
         // Check that 1 found
@@ -343,7 +345,7 @@ public class TimechartSyntaxTests {
     void xpathTest21(String arg) throws Exception {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
-        String xpathExp = "/root/transformStatement/timechartTransformation/aggregateFunction/aggregateMethodAvg/aggregate_fieldType/value";
+        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodAvg/aggregate_fieldType/value";
 
         NodeList nodesA = (NodeList) pstu.xpathQueryFile(fileName, xpathExp, false);
         // Check that 1 found
@@ -411,7 +413,7 @@ public class TimechartSyntaxTests {
 	void xpathTest26(String arg) throws Exception {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
-        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_fieldRenameInstruction/fieldType/value";
+        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_aggParameter/t_timechart_fieldRenameInstruction/fieldType/value";
 
         NodeList nodesA = (NodeList) pstu.xpathQueryFile(fileName, xpathExp, false);
         // Check that 1 found
@@ -425,11 +427,71 @@ public class TimechartSyntaxTests {
     void xpathTest27(String arg) throws Exception {
         ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
-        String xpathExp = "/root/transformStatement/timechartTransformation/aggregateFunction/aggregateMethodPercentileVariable/aggregate_fieldType/value";
+        String xpathExp = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodPercentileVariable/aggregate_fieldType/value";
 
         NodeList nodesA = (NodeList) pstu.xpathQueryFile(fileName, xpathExp, false);
         // Check that 1 found
         assertEquals(1,nodesA.getLength());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "timechart11",
+    })
+    public void testAggregationWithRename(String arg) {
+        final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
+
+        final String aggregateFunctionPath = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodSum/aggregate_fieldType/value";
+        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_aggregation/t_timechart_fieldRenameInstruction/fieldType/value";
+
+        NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
+        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+
+        assertEquals(1, aggregateFunctionNodes.getLength());
+        assertEquals(1, renameNodes.getLength());
+        assertEquals("sales", aggregateFunctionNodes.item(0).getTextContent());
+        assertEquals("sales", renameNodes.item(0).getTextContent());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "timechart4",
+    })
+    public void testAggParameterWithRename(String arg) {
+        final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
+
+        final String aggregateFunctionPath = "/root/transformStatement/timechartTransformation/t_timechart_aggParameter/aggregateFunction/aggregateMethodCount/aggregate_fieldType/value";
+        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_aggParameter/t_timechart_fieldRenameInstruction/fieldType/value";
+
+        NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
+        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+
+        assertEquals(1, aggregateFunctionNodes.getLength());
+        assertEquals(1, renameNodes.getLength());
+        assertEquals("ddd", aggregateFunctionNodes.item(0).getTextContent());
+        assertEquals("D", renameNodes.item(0).getTextContent());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "timechartEvaledField",
+    })
+    public void testEvaledFieldWithRename(String arg) {
+        final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
+
+        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
+        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_evaledField/t_timechart_fieldRenameInstruction/fieldType/value";
+
+        NodeList evalNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, evalPath, false));
+        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+
+        assertEquals(1, evalNodes.getLength());
+        assertEquals(1, renameNodes.getLength());
+        assertEquals("sales", evalNodes.item(0).getTextContent());
+        assertEquals("rounded_sales", renameNodes.item(0).getTextContent());
     }
 }
 

--- a/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
+++ b/src/test/java/com/teragrep/pth_03/tests/TimechartSyntaxTests.java
@@ -68,7 +68,8 @@ public class TimechartSyntaxTests {
             "timechart9",
             "timechart10",
             "timechart11",
-            "timechartEvaledField"
+            "timechartEvaledField",
+            "timechartAggParamEval"
     })
     public void timechartSyntaxParseTest(String arg) throws Exception {
         String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
@@ -445,8 +446,8 @@ public class TimechartSyntaxTests {
         final String aggregateFunctionPath = "/root/transformStatement/timechartTransformation/t_timechart_aggregation/aggregateFunction/aggregateMethodSum/aggregate_fieldType/value";
         final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_aggregation/t_timechart_fieldRenameInstruction/fieldType/value";
 
-        NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
-        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+        final NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
+        final NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
 
         assertEquals(1, aggregateFunctionNodes.getLength());
         assertEquals(1, renameNodes.getLength());
@@ -465,8 +466,8 @@ public class TimechartSyntaxTests {
         final String aggregateFunctionPath = "/root/transformStatement/timechartTransformation/t_timechart_aggParameter/aggregateFunction/aggregateMethodCount/aggregate_fieldType/value";
         final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_aggParameter/t_timechart_fieldRenameInstruction/fieldType/value";
 
-        NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
-        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+        final NodeList aggregateFunctionNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggregateFunctionPath, false));
+        final NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
 
         assertEquals(1, aggregateFunctionNodes.getLength());
         assertEquals(1, renameNodes.getLength());
@@ -482,16 +483,36 @@ public class TimechartSyntaxTests {
         final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
         final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
 
-        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
-        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_evaledField/t_timechart_fieldRenameInstruction/fieldType/value";
+        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_renamedEvaledField/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
+        final String renamePath = "root/transformStatement/timechartTransformation/t_timechart_renamedEvaledField/t_timechart_fieldRenameInstruction/fieldType/value";
 
-        NodeList evalNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, evalPath, false));
-        NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
+        final NodeList evalNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, evalPath, false));
+        final NodeList renameNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, renamePath, false));
 
         assertEquals(1, evalNodes.getLength());
         assertEquals(1, renameNodes.getLength());
         assertEquals("sales", evalNodes.item(0).getTextContent());
         assertEquals("rounded_sales", renameNodes.item(0).getTextContent());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "timechartAggParamEval",
+    })
+    public void testEvaledFieldInAggParam(String arg) {
+        final ParserStructureTestingUtility pstu = new ParserStructureTestingUtility();
+        final String fileName = "src/test/resources/antlr4/commands/timechart/" + arg + ".txt";
+
+        final String aggPath = "/root/transformStatement/timechartTransformation/t_timechart_aggParameter/value";
+        final String evalPath = "/root/transformStatement/timechartTransformation/t_timechart_aggParameter/t_timechart_evaledField/evalStatement/evalFunctionStatement/evalMethodRound/evalStatement/evalFieldType/value";
+
+        final NodeList aggNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, aggPath, false));
+        final NodeList evalNodes = assertDoesNotThrow(() -> (NodeList) pstu.xpathQueryFile(fileName, evalPath, false));
+
+        assertEquals(1, aggNodes.getLength());
+        assertEquals(1, evalNodes.getLength());
+        assertEquals("agg=", aggNodes.item(0).getTextContent());
+        assertEquals("sales", evalNodes.item(0).getTextContent());
     }
 }
 

--- a/src/test/resources/antlr4/commands/timechart/timechartAggParamEval.txt
+++ b/src/test/resources/antlr4/commands/timechart/timechartAggParamEval.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+| timechart agg=eval(round(sales, 3)) count by x

--- a/src/test/resources/antlr4/commands/timechart/timechartEvaledField.txt
+++ b/src/test/resources/antlr4/commands/timechart/timechartEvaledField.txt
@@ -1,0 +1,46 @@
+<!-- /*
+ * Teragrep Data Processing Language Parser Library PTH-03
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */ -->
+| timechart eval(round(sales, 3)) as rounded_sales


### PR DESCRIPTION
Fixes #92 .

Moved renaming columns in aggregations and evaluations under new grammar rules together with the column that is going to be renamed. This makes it possible to traverse the parse tree in any order in PTH-10 without losing information about which renaming instruction corresponds to which column. Previously the rename instruction had to be parsed directly after the corresponding column, which makes parsing unnecessarily difficult.

Created tests to assert the parse tree is correct in these cases.

The grammar should not have changed at all in this PR! Only the grammar rules change, which creates a need for changes in PTH-10 when traversing the parse tree. DPL language stays the same though.

Evaluation functions had no tests yet in timechart. New issue #93 was opened about those, as a bug was found when testing them. The test introduced in this PR makes sure that the renaming of eval functions works as intended.